### PR TITLE
fix(e2e): switch to Media Library tab before selecting attachment

### DIFF
--- a/tests/e2e/specs/admin/interactive.spec.js
+++ b/tests/e2e/specs/admin/interactive.spec.js
@@ -291,6 +291,11 @@ test.describe( 'Interactive Kitchen Sink', () => {
 			const modal = page.locator( '.media-modal' );
 			await expect( modal ).toBeVisible( { timeout: 5000 } );
 
+			// Modal opens on the "Upload files" tab by default; switch to the library.
+			await modal
+				.locator( '.media-router .media-menu-item:has-text("Media Library")' )
+				.click();
+
 			// Log the AJAX response for CI debugging.
 			const ajaxResponse = await ajaxPromise;
 			if ( ajaxResponse ) {
@@ -327,6 +332,9 @@ test.describe( 'Interactive Kitchen Sink', () => {
 			);
 			const modal = page.locator( '.media-modal' );
 			await expect( modal ).toBeVisible( { timeout: 5000 } );
+			await modal
+				.locator( '.media-router .media-menu-item:has-text("Media Library")' )
+				.click();
 			await modal.locator( '.attachment' ).first().click();
 			await page.click( '.media-button-select' );
 			await expect( modal ).not.toBeVisible();
@@ -346,6 +354,9 @@ test.describe( 'Interactive Kitchen Sink', () => {
 			);
 			const modal = page.locator( '.media-modal' );
 			await expect( modal ).toBeVisible( { timeout: 5000 } );
+			await modal
+				.locator( '.media-router .media-menu-item:has-text("Media Library")' )
+				.click();
 			await modal.locator( '.attachment' ).first().click();
 			await page.click( '.media-button-select' );
 			await expect( modal ).not.toBeVisible();

--- a/tests/e2e/specs/admin/interactive.spec.js
+++ b/tests/e2e/specs/admin/interactive.spec.js
@@ -277,12 +277,6 @@ test.describe( 'Interactive Kitchen Sink', () => {
 		test( 'selecting an attachment sets the hidden input and shows a preview', async ( {
 			page,
 		} ) => {
-			// Intercept the query-attachments AJAX to diagnose CI empty-grid issue.
-			const ajaxPromise = page.waitForResponse(
-				( r ) => r.url().includes( 'query-attachments' ) || r.url().includes( 'wp/v2/media' ),
-				{ timeout: 10000 }
-			).catch( () => null );
-
 			await page.click(
 				'.pc-settings-media-select[data-key="media_image"]'
 			);
@@ -296,17 +290,6 @@ test.describe( 'Interactive Kitchen Sink', () => {
 				.locator( '.media-router .media-menu-item:has-text("Media Library")' )
 				.click();
 
-			// Log the AJAX response for CI debugging.
-			const ajaxResponse = await ajaxPromise;
-			if ( ajaxResponse ) {
-				const body = await ajaxResponse.text().catch( () => '(unreadable)' );
-				console.log( `[DIAG] query-attachments status=${ ajaxResponse.status() } url=${ ajaxResponse.url() }` );
-				console.log( `[DIAG] response body (first 500 chars): ${ body.substring( 0, 500 ) }` );
-			} else {
-				console.log( '[DIAG] No query-attachments or wp/v2/media response intercepted within 10s' );
-			}
-
-			// The seeded attachment should appear in the library.
 			// Click the first attachment in the grid.
 			const attachment = modal.locator( '.attachment' ).first();
 			await expect( attachment ).toBeVisible( { timeout: 10000 } );


### PR DESCRIPTION
The WP media modal opens on the "Upload files" tab by default, not "Media Library". The three Media Library specs were trying to click .attachment in the grid without switching tabs, so they timed out because the library list never rendered.

Adds the tab switch in:
- selecting an attachment sets the hidden input and shows a preview
- selected media persists after submit
- clearing the selection empties the hidden input